### PR TITLE
Initialize offline-first SPA foundation with Supabase, PWA, i18n, and stores

### DIFF
--- a/src/app/providers/AuthListener.tsx
+++ b/src/app/providers/AuthListener.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { supabase } from '@/services/SupabaseService'
+import { SupabaseSyncService } from '@/services/SupabaseSyncService'
+
+export function AuthListener() {
+  useEffect(() => {
+    const { data: sub } = supabase.auth.onAuthStateChange(async (event) => {
+      if (event === 'SIGNED_IN') {
+        await SupabaseSyncService.syncAll()
+      }
+    })
+    return () => {
+      sub.subscription.unsubscribe()
+    }
+  }, [])
+  return null
+}

--- a/src/app/providers/Providers.tsx
+++ b/src/app/providers/Providers.tsx
@@ -4,8 +4,15 @@ import i18n from '@/app/i18n'
 import { useRTL } from '@/hooks/useRTL'
 import { useThemeTokens } from '@/hooks/useThemeTokens'
 
+import { AuthListener } from './AuthListener'
+
 export function AppProviders({ children }: PropsWithChildren) {
   useRTL()
   useThemeTokens()
-  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+  return (
+    <I18nextProvider i18n={i18n}>
+      <AuthListener />
+      {children}
+    </I18nextProvider>
+  )
 }

--- a/src/services/SupabaseSyncService.ts
+++ b/src/services/SupabaseSyncService.ts
@@ -1,0 +1,174 @@
+import { supabase } from './SupabaseService'
+import { db, type Note, type Progress as ProgressLocal, type AttemptLocal } from './IndexedDBService'
+
+function isNewer(a?: number, b?: number) {
+  return (a || 0) > (b || 0)
+}
+
+export const SupabaseSyncService = {
+  async getUserId() {
+    const { data } = await supabase.auth.getUser()
+    return data.user?.id || null
+  },
+
+  async syncAll() {
+    const userId = await this.getUserId()
+    if (!userId) return
+    await Promise.all([
+      this.syncNotes(userId),
+      this.syncProgress(userId),
+      this.syncAttempts(userId),
+    ])
+  },
+
+  async syncNotes(userId: string) {
+    const local = await db.notes.toArray()
+    const { data: remote, error } = await supabase
+      .from('notes')
+      .select('id, lesson_id, content, bookmark_ts, updated_at')
+      .eq('user_id', userId)
+    if (error) return
+
+    const map = new Map<string, any>()
+    for (const r of remote || []) map.set(r.id, r)
+
+    const merged: Note[] = []
+    for (const n of local) {
+      const r = map.get(n.id)
+      if (!r) {
+        merged.push(n)
+      } else {
+        const rUpdated = r.updated_at ? new Date(r.updated_at).getTime() : 0
+        merged.push(isNewer(n.updatedAt, rUpdated)
+          ? n
+          : { id: r.id, lessonId: r.lesson_id, content: r.content || '', bookmarkTs: r.bookmark_ts || undefined, updatedAt: rUpdated })
+        map.delete(n.id)
+      }
+    }
+    for (const r of map.values()) {
+      const rUpdated = r.updated_at ? new Date(r.updated_at).getTime() : 0
+      merged.push({ id: r.id, lessonId: r.lesson_id, content: r.content || '', bookmarkTs: r.bookmark_ts || undefined, updatedAt: rUpdated })
+    }
+
+    await db.transaction('rw', db.notes, async () => {
+      await db.notes.clear()
+      await db.notes.bulkAdd(merged)
+    })
+
+    const payload = merged.map((n) => ({
+      id: n.id,
+      user_id: userId,
+      lesson_id: n.lessonId,
+      content: n.content,
+      bookmark_ts: n.bookmarkTs ?? null,
+      updated_at: new Date(n.updatedAt).toISOString(),
+    }))
+    await supabase.from('notes').upsert(payload)
+  },
+
+  async syncProgress(userId: string) {
+    const local = await db.progress.toArray()
+    const { data: remote, error } = await supabase
+      .from('progress')
+      .select('id, lesson_id, video_ts, audio_ts, completed, last_seen')
+      .eq('user_id', userId)
+    if (error) return
+
+    const byId = new Map<string, any>()
+    for (const r of remote || []) byId.set(r.id, r)
+
+    const merged: ProgressLocal[] = []
+    for (const p of local) {
+      const r = byId.get(p.id)
+      if (!r) merged.push(p)
+      else {
+        const rSeen = r.last_seen ? new Date(r.last_seen).getTime() : 0
+        merged.push(isNewer(p.lastSeen, rSeen)
+          ? p
+          : { id: r.id, lessonId: r.lesson_id, videoTs: r.video_ts ?? undefined, audioTs: r.audio_ts ?? undefined, completed: !!r.completed, lastSeen: rSeen })
+        byId.delete(p.id)
+      }
+    }
+    for (const r of byId.values()) {
+      const rSeen = r.last_seen ? new Date(r.last_seen).getTime() : 0
+      merged.push({ id: r.id, lessonId: r.lesson_id, videoTs: r.video_ts ?? undefined, audioTs: r.audio_ts ?? undefined, completed: !!r.completed, lastSeen: rSeen })
+    }
+
+    await db.transaction('rw', db.progress, async () => {
+      await db.progress.clear()
+      await db.progress.bulkAdd(merged)
+    })
+
+    const payload = merged.map((p) => ({
+      id: p.id,
+      user_id: userId,
+      lesson_id: p.lessonId,
+      video_ts: p.videoTs ?? null,
+      audio_ts: p.audioTs ?? null,
+      completed: !!p.completed,
+      last_seen: new Date(p.lastSeen).toISOString(),
+    }))
+    await supabase.from('progress').upsert(payload)
+  },
+
+  async syncAttempts(userId: string) {
+    const local = await db.attempts.toArray()
+    const { data: remote, error } = await supabase
+      .from('attempts')
+      .select('id, quiz_id, score, details, started_at, finished_at')
+      .eq('user_id', userId)
+    if (error) return
+
+    const byId = new Map<string, any>()
+    for (const r of remote || []) byId.set(r.id, r)
+
+    const merged: AttemptLocal[] = []
+    for (const a of local) {
+      const r = byId.get(a.id)
+      if (!r) merged.push({ ...a, userId })
+      else {
+        const tLocal = a.finishedAt || a.startedAt
+        const tRemote = (r.finished_at ? new Date(r.finished_at).getTime() : 0) || (r.started_at ? new Date(r.started_at).getTime() : 0)
+        merged.push(isNewer(tLocal, tRemote)
+          ? { ...a, userId }
+          : {
+              id: r.id,
+              quizId: r.quiz_id,
+              userId,
+              score: r.score ?? undefined,
+              details: r.details ?? undefined,
+              startedAt: r.started_at ? new Date(r.started_at).getTime() : 0,
+              finishedAt: r.finished_at ? new Date(r.finished_at).getTime() : undefined,
+            })
+        byId.delete(a.id)
+      }
+    }
+    for (const r of byId.values()) {
+      merged.push({
+        id: r.id,
+        quizId: r.quiz_id,
+        userId,
+        score: r.score ?? undefined,
+        details: r.details ?? undefined,
+        startedAt: r.started_at ? new Date(r.started_at).getTime() : 0,
+        finishedAt: r.finished_at ? new Date(r.finished_at).getTime() : undefined,
+      })
+    }
+
+    await db.transaction('rw', db.attempts, async () => {
+      await db.attempts.clear()
+      await db.attempts.bulkAdd(merged)
+    })
+
+    const payload = merged.map((a) => ({
+      id: a.id,
+      user_id: userId,
+      quiz_id: a.quizId,
+      score: a.score ?? null,
+      details: a.details ?? null,
+      started_at: new Date(a.startedAt).toISOString(),
+      finished_at: a.finishedAt ? new Date(a.finishedAt).toISOString() : null,
+    }))
+    await supabase.from('attempts').upsert(payload)
+  },
+}

--- a/supabase/migrations/0002_storage_policies.sql
+++ b/supabase/migrations/0002_storage_policies.sql
@@ -1,5 +1,5 @@
 -- Create media bucket (run once)
-insert into storage.buckets (id, name, public) values ('media','media', true)
+insert into storage.buckets (id, public) values ('media', true)
   on conflict (id) do nothing;
 
 -- Policies on storage.objects

--- a/supabase/migrations/0002_storage_policies.sql
+++ b/supabase/migrations/0002_storage_policies.sql
@@ -1,0 +1,32 @@
+-- Create media bucket (run once)
+insert into storage.buckets (id, name, public) values ('media','media', true)
+  on conflict (id) do nothing;
+
+-- Policies on storage.objects
+alter table storage.objects enable row level security;
+
+create policy if not exists "Public read media"
+  on storage.objects for select using ( bucket_id = 'media' );
+
+create policy if not exists "Teachers/Admin can upload to media"
+  on storage.objects for insert with check (
+    bucket_id = 'media' and exists (
+      select 1 from public.profiles p where p.id = auth.uid() and p.role in ('teacher','admin')
+    )
+  );
+
+create policy if not exists "Teachers/Admin can update media"
+  on storage.objects for update using (
+    bucket_id = 'media' and exists (
+      select 1 from public.profiles p where p.id = auth.uid() and p.role in ('teacher','admin')
+    )
+  ) with check (
+    bucket_id = 'media'
+  );
+
+create policy if not exists "Teachers/Admin can delete media"
+  on storage.objects for delete using (
+    bucket_id = 'media' and exists (
+      select 1 from public.profiles p where p.id = auth.uid() and p.role in ('teacher','admin')
+    )
+  );


### PR DESCRIPTION
# Initialize offline-first study SPA foundation

This PR lays a production-ready groundwork for the Subjects → Sections → Lessons platform, focusing on an offline-first experience with Supabase sync and bilingual (AR/EN) UI with RTL support. The goal is to accelerate subsequent feature work (teacher tools, full quiz engine, advanced media, analytics) atop a solid architecture.

## Summary (why)
- Establish a cohesive, scalable baseline (routing, state, theming, PWA, data stores) so that new features ship faster and consistently.
- Enable account/sync early to validate data flows (local IndexedDB ↔ Supabase) and reduce integration risk later.
- Make the app immediately installable and usable offline to support unreliable connectivity scenarios.

## Changes (what)
- App scaffold: Vite + React + TS + Tailwind (design tokens) + shadcn/ui components.
- PWA: vite-plugin-pwa with manifest, SW auto-update.
- i18n + RTL: i18next (AR/EN), automatic dir/lang via hooks.
- Theming/Accessibility: CSS tokens (emerald/amber/cyan; zinc surfaces), ThemeController, accessibility controls (font scale, reduced motion, captions/TTS flags), persisted locally.
- State: Zustand stores for settings, auth, content (sample), progress, quiz.
- Offline storage: Dexie schema (media, notes, progress, quizzes, attempts, annotations, settings, content).
- Supabase: client wiring + migrations (tables, RLS), storage policies for `media` bucket.
- Sync: SupabaseSyncService for notes/progress/attempts with last-write-wins (most recent timestamp), AuthListener triggers sync on sign-in.
- Routing/pages (lazy): Home, Subject, Section, Lesson, LessonMedia, Quiz, Settings, Dashboard, AdvancedSearch, Onboarding, Help.
- Lesson components (initial): Video/Audio players, PDFViewer, DiagramCarousel, NotesPanel, QuickQuizWidget, playlists.
- Dev tooling: Storybook (sample stories), Vitest + RTL (sample test), Playwright scaffold, README.

## Setup
1) Install deps: `bun install`
2) Env: copy `.env.example` to `.env` and set `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`.
3) Supabase (CLI):
   ```bash
   supabase login
   supabase link --project-ref urzxbbqelpnzitqvffhs
   supabase db push
   ```
4) Run dev: `bun run dev` (Storybook: `bun run storybook`, Tests: `bun run test`).

## Impact
- No breaking changes to existing codebase (new app foundation).
- Introduces required infra for PWA, auth, and offline data. Further features can be added incrementally.

## Acceptance alignment
- Installable PWA, offline-first baseline with IndexedDB + sync stubs.
- AR/EN with RTL support and high-contrast theme.
- Settings modify CSS variables live and persist.
- Lesson/Media/Quiz pages stubbed, ready for full implementations.
- Supabase migrations (tables/RLS) and storage policies for `media` included.
- Storybook/tests scaffolds added.

## Next steps (proposed)
- Auth UI (OTP) in header + basic account screen to exercise sync.
- Teacher dashboard CRUD + media uploads to `media` bucket.
- Full quiz engine types + results analytics + sync.
- PDF annotations persisted locally; advanced media resume and captions/transcripts.
- AdvancedSearch backed by MiniSearch + Supabase data.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/43f0f7a9-8302-4f12-bb64-8840d70304b5/task/ec4cbad0-1580-436a-bcd2-4755f945d348))